### PR TITLE
Fixed up some logic and added user profiles and inboxes

### DIFF
--- a/elo/settings.py
+++ b/elo/settings.py
@@ -94,7 +94,7 @@ STATIC_URL = '/static/'
 #STATIC_ROOT = '/home/gordon/public/laddr.org/elo/static/'
 
 # Steam API key
-STEAM_API_KEY = '87B1E6B2C33AA7850637787CF4BAC545'
+STEAM_API_KEY = 'super secret steam key'
 
 # Authentification for OpenID
 AUTHENTICATION_BACKENDS = (


### PR DESCRIPTION
This pull request includes changes that fix some broken functionality as well as introducing basic user profiles and messaging interfaces. :godmode:
- Ladder admin page now has inline rankings
- `_get_valid_targets` now properly returns  valid opponents
- Challenge buttons now do something
- Added user profiles
- Added links to user profiles
- Added user inbox (currently only supports Challenges and Matches)
